### PR TITLE
Ensure root directories exist when writing output

### DIFF
--- a/packages/prisma-import/src/merge.ts
+++ b/packages/prisma-import/src/merge.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { readFile, writeFile } from './util'
+import { ensureDirectoryExistence, readFile, writeFile } from './util'
 import { format } from '@prisma/prisma-fmt-wasm'
 import { pathToFileURL } from 'url'
 
@@ -54,6 +54,7 @@ export const merge = async (schemaPaths: string[], outputPath: string, dry: bool
   if (dry) {
     console.log(resultingSchema)
   } else {
+    await ensureDirectoryExistence(outputPath)
     await writeFile(outputPath, resultingSchema)
   }
 }

--- a/packages/prisma-import/src/util.ts
+++ b/packages/prisma-import/src/util.ts
@@ -1,14 +1,49 @@
 import { getPrismaConfigFromPackageJson } from '@prisma/internals'
 import { PrismaImportConfig } from './types'
 import fs from 'fs'
+import path from 'path'
 import _glob from 'glob'
 import { promisify } from 'util'
 
-export const exists = promisify(fs.exists)
+export const stat = promisify(fs.stat)
 export const readFile = promisify(fs.readFile)
 export const mkdir = promisify(fs.mkdir)
 export const writeFile = promisify(fs.writeFile)
 export const glob = promisify(_glob)
+
+/**
+ * Determines if a path already exists. This is a replacement for `fs.exists`
+ * which is deprecated.
+ */
+export async function exists(filePath: string) {
+  try {
+    await stat(filePath)
+    return true
+  } catch (error) {
+    if (isErrnoException(error) && error.code == 'ENOENT') {
+      return false
+    }
+    throw error
+  }
+}
+
+function isErrnoException(e: unknown): e is NodeJS.ErrnoException {
+  return 'code' in (e as any)
+}
+
+/**
+ * Given a file path ensures that the directories preceeding the file all exist
+ * by creating those which don't.
+ *
+ * Example:
+ * The path `/foo/bar/baz.txt` would ensure that `/foo/bar/` exists.
+ */
+export async function ensureDirectoryExistence(filePath: string) {
+  const dirname = path.dirname(filePath)
+  if (!(await exists(dirname))) {
+    await mkdir(dirname, { recursive: true })
+  }
+}
 
 export const getConfigFromPackageJson = async (
   key: keyof NonNullable<PrismaImportConfig['import']>,


### PR DESCRIPTION
## Problem

Currently output file require that all proceeding directories already exist. This is not always the case, for example the default prisma file location is `prisma/schema.prisma`. So it is reasonable for a project to *not* include the directory `prisma/` until the schema file is generated by this extension.

### Example:

The command

```
npx prisma-import --schemas 'prisma/**/*.prisma' --output 'generated/prisma/schema.prisma'
```

yields

```
node:internal/process/promises:246
          triggerUncaughtException(err, true /* fromPromise */);
          ^

[Error: ENOENT: no such file or directory, open '/{pathToRepo}/generated/prisma/schema.prisma'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/{pathToRepo}/generated/prisma/schema.prisma'
}

Node.js v17.3.0
```

## Solution

When writing output files we should first check to see if the parent directory exists, and if not, create it.