### PR TITLE
fix: allow imports to contain a number that is not the starting character

### DIFF
--- a/packages/vscode/syntaxes/prisma.tmLanguage.json
+++ b/packages/vscode/syntaxes/prisma.tmLanguage.json
@@ -441,7 +441,7 @@
       ]
     },
     "import_block_definition": {
-      "match": "^\\s*(import)\\s*({)\\s*(([A-Za-z][A-Za-z0-9]+,?\\s*)+)\\s*(})\\s*(from)\\s*(\".*\")",
+      "match": "^\\s*(import)\\s*({)\\s*(([A-Za-z][A-Za-z0-9]*,?\\s*)+)\\s*(})\\s*(from)\\s*(\".*\")",
       "name": "source.prisma.embedded.source",
       "captures": {
         "1": {

--- a/packages/vscode/syntaxes/prisma.tmLanguage.json
+++ b/packages/vscode/syntaxes/prisma.tmLanguage.json
@@ -441,7 +441,7 @@
       ]
     },
     "import_block_definition": {
-      "match": "^\\s*(import)\\s*({)\\s*(([A-Za-z]+,?\\s*)+)\\s*(})\\s*(from)\\s*(\".*\")",
+      "match": "^\\s*(import)\\s*({)\\s*(([A-Za-z][A-Za-z0-9]+,?\\s*)+)\\s*(})\\s*(from)\\s*(\".*\")",
       "name": "source.prisma.embedded.source",
       "captures": {
         "1": {


### PR DESCRIPTION
I have some models that contain numbers as part of the definition however they aren't being detected as valid import

![image](https://user-images.githubusercontent.com/1113900/209803812-9c9cad00-e220-4fda-8b86-7961fd28bbe9.png)

Validation:
Happy to write a unit test if pointed to the right location to add
![image](https://user-images.githubusercontent.com/1113900/209816362-dc8d059c-fd82-48c4-833c-c289ec961f51.png)
