### PR TITLE
Extend functionality

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,7 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "sourceMaps": true,
+      "preLaunchTask": "build",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}/packages/vscode", "--disable-extensions"],
       "outFiles": ["${workspaceFolder}/packages/vscode/dist/**/*.js"],
       "env": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+  "version": "2.0.0",
+  "tasks": [{
+    "label": "build-ls",
+    "command": "npm", // Could be any other shell command
+    "args": ["run", "build:ls"],
+    "type": "shell"
+  }, {
+      "label": "build-vs",
+      "command": "npm", // Could be any other shell command
+      "args": ["run", "build:vs"],
+      "type": "shell"
+  }, {
+      "label": "build",
+      "dependsOn": ["build-ls", "build-vs"],
+      "type": "shell"
+  }]
+}

--- a/packages/language-server/src/__test__/completion.test.ts
+++ b/packages/language-server/src/__test__/completion.test.ts
@@ -186,6 +186,7 @@ suite('Completions', function () {
             { label: 'model', kind: CompletionItemKind.Class },
             { label: 'import', kind: CompletionItemKind.Class },
             { label: 'enum', kind: CompletionItemKind.Class },
+            { label: 'extend', kind: CompletionItemKind.Class },
           ],
         },
       })
@@ -206,6 +207,7 @@ suite('Completions', function () {
             { label: 'generator', kind: CompletionItemKind.Class },
             { label: 'model', kind: CompletionItemKind.Class },
             { label: 'import', kind: CompletionItemKind.Class },
+            { label: 'enum', kind: CompletionItemKind.Class },
           ],
         },
       })

--- a/packages/language-server/src/codeActionProvider.ts
+++ b/packages/language-server/src/codeActionProvider.ts
@@ -186,6 +186,7 @@ export function quickFix(textDocument: TextDocument, params: CodeActionParams): 
           'datasource',
           'generator',
           'import',
+          'extend',
         ])
         if (spellingSuggestion) {
           codeActions.push({

--- a/packages/language-server/src/completion/completionUtils.ts
+++ b/packages/language-server/src/completion/completionUtils.ts
@@ -554,5 +554,6 @@ export const blockTypeToCompletionItemKind = (type: BlockType) => {
     datasource: CompletionItemKind.Struct,
     generator: CompletionItemKind.Function,
     import: CompletionItemKind.Struct,
+    extend: CompletionItemKind.Class,
   }[type]
 }

--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -70,6 +70,10 @@
     {
       "label": "enum",
       "documentation": "Enums are defined via the enum block. You can define enums in your data model if they're supported by the datasource you use (e.g SQLite: not supported)."
+    },
+    {
+      "label": "extend",
+      "documentation": "Extend a model from another schema."
     }
   ],
   "dataSourceFields": [

--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -229,7 +229,7 @@ export function getSuggestionsForFieldTypes(
     const importableSchemas = getAllSchemas().filter((s) => s.path !== fileURLToPath(document.uri))
 
     for (const schema of importableSchemas) {
-      const importableBlocks = schema.blocks.filter((b) => ['enum', 'model', 'type'].includes(b.type))
+      const importableBlocks = schema.blocks.filter((b) => ['enum', 'model', 'type', 'extend'].includes(b.type))
       const relativeSchemaPath = absoluteToRelativePath(document, schema.path)
 
       for (const block of importableBlocks) {
@@ -1150,7 +1150,7 @@ export function getSuggestionsForImportBlocks(document: TextDocument, currentLin
 
   return {
     items: schemaMatch.blocks
-      .filter((b) => ['enum', 'model', 'type'].includes(b.type))
+      .filter((b) => ['enum', 'model', 'type', 'extend'].includes(b.type))
       .map((b) => ({
         kind: blockTypeToCompletionItemKind(b.type),
         label: b.name,

--- a/packages/language-server/src/util.ts
+++ b/packages/language-server/src/util.ts
@@ -6,7 +6,7 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import { getAllSchemas } from './imports'
 
-export type BlockType = 'generator' | 'datasource' | 'model' | 'type' | 'enum' | 'import'
+export type BlockType = 'generator' | 'datasource' | 'model' | 'type' | 'enum' | 'import' | 'extend'
 export type ImportedBlock = { name: string; range: Range }
 export class Block {
   type: BlockType
@@ -134,7 +134,7 @@ export function* getBlocks(lines: string[]): Generator<Block, void, void> {
   let blockType = ''
   let blockNameRange: Range | undefined
   let blockStart: Position = Position.create(0, 0)
-  const allowedBlockIdentifiers: BlockType[] = ['model', 'type', 'enum', 'datasource', 'generator']
+  const allowedBlockIdentifiers: BlockType[] = ['model', 'type', 'enum', 'extend', 'datasource', 'generator']
 
   for (const [key, item] of lines.entries()) {
     if (item.startsWith('import')) {

--- a/packages/language-server/src/virtual-schema.ts
+++ b/packages/language-server/src/virtual-schema.ts
@@ -29,6 +29,8 @@ export const getVirtualSchema = (document: TextDocument) => {
     .filter((b) => ['enum', 'type', 'model'].includes(b.type))
     .map((b) => b.name)
 
+  const documentSchemaExtendBlocks = documentSchema.blocks.filter((b) => b.type === 'extend')
+
   // Find direct imports in document schema so we can add
   // them as non-virtualized
 
@@ -161,6 +163,16 @@ export const getVirtualSchema = (document: TextDocument) => {
 
           searchBlocks(importBlockSchema, [fieldBlockName])
           continue
+        }
+      }
+
+      for (const extendedBlock of documentSchemaExtendBlocks) {
+        if (new RegExp(`(type|model) ${extendedBlock.name}`, 'g').test(blockText)) {
+          const extendedBody = document.getText(extendedBlock.range).split('\n')
+          extendedBody.shift() // remove block declaration line
+          extendedBody.pop() // remove block closing line
+          blockText = blockText.replace('}', `${extendedBody.join('\n')}\n}`)
+          break
         }
       }
 

--- a/packages/vscode/syntaxes/prisma.tmLanguage.json
+++ b/packages/vscode/syntaxes/prisma.tmLanguage.json
@@ -24,6 +24,9 @@
     },
     {
       "include": "#import_block_definition"
+    },
+    {
+      "include": "#extend_block_definition"
     }
   ],
   "repository": {
@@ -467,6 +470,38 @@
         }
       },
       "patterns": []
+    },
+    "extend_block_definition": {
+      "begin": "^\\s*(extend)\\s+([A-Za-z][\\w]*)\\s*({)",
+      "name": "source.prisma.embedded.source",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.model.prisma"
+        },
+        "2": {
+          "name": "entity.name.type.model.prisma"
+        },
+        "3": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#triple_comment"
+        },
+        {
+          "include": "#double_comment"
+        },
+        {
+          "include": "#field_definition"
+        }
+      ],
+      "end": "\\s*\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Note: It is my first time touching vscode extension/language-server code, so I'm really open for suggestions or code review commits.

This is crude implementation of basic extend functionality that works like this:

1. When parsing currently open schema file we append extended model/type properties to the imported model/type and comment out extend blocks.
2. Similarly to the way import works, the extend blocks are being commented out when formatting. 
3. prisma-import cli appends extended model/type properties as well and deletes extend blocks afterwards.

Final result is just like how I proposed the idea in this comment: https://github.com/ajmnz/prisma-import/issues/27#issuecomment-1471132685

Current issues:
Would be nice to have formatting/autocomplete inside extend blocks, but without altering prisma internals I'm not sure if it is possible.

Handled edge cases:

* It is possible to extend only imported blocks, the error is shown otherwise.
* If you redeclare already existing property (in the imported block) inside the extend block, error is shown.